### PR TITLE
Bundlerのアップデート

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
     execjs (2.7.0)
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.18)
+    ffi (1.13.1)
     forwardable-extended (2.6.0)
     gemoji (3.0.0)
     github-pages (171)
@@ -223,4 +223,4 @@ DEPENDENCIES
   github-pages
 
 BUNDLED WITH
-   1.15.4
+   2.1.4

--- a/docker/jekyll/Dockerfile
+++ b/docker/jekyll/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4.1
+FROM ruby:2.7.1
 
 WORKDIR /app
 


### PR DESCRIPTION
Netlifyでjekyllが動かない問題対策